### PR TITLE
Add Node 24 to CI matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
-          cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node: [20, 22]
+        node: [20, 22, 24]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -11,11 +11,10 @@
 
 <br />
 <div align="center">
-  <!-- Github Actions
-  <a href="https://github.com/fractality/fractality/actions" title="Build status">
-    <img src="https://img.shields.io/github/workflow/status/fractality/fractality/test/main" alt="">
+  <!-- Github Actions -->
+  <a href="https://github.com/sitepark/fractality/actions/workflows/test.yml" title="Build status">
+    <img src="https://github.com/sitepark/fractality/actions/workflows/test.yml/badge.svg" alt="">
   </a>
-  -->
   <!-- NPM Version -->
   <a href="https://www.npmjs.com/package/@fractality/fractality" title="Current version">
     <img src="https://img.shields.io/npm/v/@fractality/fractality.svg" alt="">

--- a/packages/fractality/README.md
+++ b/packages/fractality/README.md
@@ -12,8 +12,8 @@
 <br />
 <div align="center">
   <!-- Github Actions -->
-  <a href="https://github.com/sitepark/fractality/actions" title="Build status">
-    <img src="https://img.shields.io/github/workflow/status/sitepark/fractality/test/main" alt="">
+  <a href="https://github.com/sitepark/fractality/actions/workflows/test.yml" title="Build status">
+    <img src="https://github.com/sitepark/fractality/actions/workflows/test.yml/badge.svg" alt="">
   </a>
   <!-- NPM Version -->
   <a href="https://www.npmjs.com/package/@fractality/fractality" title="Current version">


### PR DESCRIPTION
This refreshes the CI, and updates a few spots around it.

The last actions runs appear logged with failure; I wasn't able to reproduce, the CI seems currently passing. For good measure I removed the empty file test artifact, and added current active (future LTS) Node version for visibility.

I removed any cache restoring from release pipeline for security reasons.
_(Generally the ~5sec saved in reusing cached packages is spent on ~5sec restoring caches, so… 🤷)_

There were a few CI status badges, incl. on the readme published to a package npmjs page, so I updated these to use current format.

Tested for both windows-2022 and windows-2025 whatever gets picked up as the latest tag runner.

NB: This recent Node 24 addition sheds some light on future deprecations:

> <img width="2300" height="534" alt="actions test summary success" src="https://github.com/user-attachments/assets/600de8f1-a888-4842-a595-0eaf4f083340" />